### PR TITLE
add IsNull helper method

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -571,6 +571,15 @@ func (t Result) Exists() bool {
 	return t.Type != Null || len(t.Raw) != 0
 }
 
+// IsNull returns true if type is Null.
+//
+//  if gjson.Get(json, "name.nullable").IsNull() {
+//		println("value is null")
+//  }
+func (t Result) IsNull() bool {
+	return t.Type == Null
+}
+
 // Value returns one of these types:
 //
 //	bool, for JSON booleans

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -136,7 +136,8 @@ var basicJSON = `{"age":100, "name":{"here":"B\\\"R"},
 			}
     	]
 	},
-	"lastly":{"yay":"final"}
+	"lastly":{"yay":"final"},
+	"nullable": null
 }`
 var basicJSONB = []byte(basicJSON)
 
@@ -238,6 +239,12 @@ func TestIsArrayIsObject(t *testing.T) {
 	mtok = get(basicJSON, `loggy.programmers.0.firstName`)
 	assert(t, !mtok.IsObject())
 	assert(t, !mtok.IsArray())
+}
+
+func TestIsNull(t *testing.T) {
+	value := get(basicJSON, "nullable")
+	assert(t, value.IsNull())
+	assert(t, value.Exists())
 }
 
 func TestPlus53BitInts(t *testing.T) {


### PR DESCRIPTION
Hi @tidwall 

json allows nullable value in body so that we can't use `Exists` method for this case.

For now, we can use `p.Type == gjson.Null` to check the value is NULL. In HTTP PATCH method, it's very common case in implementation. So, could we make it graceful by providing helper `IsNull` like `IsArray`? Does it make senses to you?  