### PR TITLE
Result.Bool() can parse 'false' as false

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -96,7 +96,7 @@ func (t Result) Bool() bool {
 	case True:
 		return true
 	case String:
-		return t.Str != "" && t.Str != "0"
+		return t.Str != "" && t.Str != "0" && t.Str != "false"
 	case Number:
 		return t.Num != 0
 	}

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -148,7 +148,7 @@ func TestTimeResult(t *testing.T) {
 func TestParseAny(t *testing.T) {
 	assert(t, Parse("100").Float() == 100)
 	assert(t, Parse("true").Bool())
-	assert(t, Parse("valse").Bool() == false)
+	assert(t, Parse("false").Bool() == false)
 }
 
 func TestManyVariousPathCounts(t *testing.T) {


### PR DESCRIPTION
Hi, @tidwall 

I hope gjson can parse "false" as false and I made it.
In standard JSON, "false" shouldn't be equal to false. However, given that gjson is really useful and ergonomic, I always translate XML or YAML to JSON and parse it using gjson.
In XML or YAML, it's hard to judge if a "false" is string or bool, so we always regard it as string when it is translated to JSON.

Thank you.