### PR TITLE
Set Index property for contained Results when loading object properties into a GoLang map

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -308,6 +308,7 @@ func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
 	var value Result
 	var count int
 	var key Result
+	var index = 0
 	if vc == 0 {
 		for ; i < len(json); i++ {
 			if json[i] == '{' || json[i] == '[' {
@@ -385,7 +386,9 @@ func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
 				if valueize {
 					r.oi[key.Str] = value.Value()
 				} else {
+					value.Index = index
 					r.o[key.Str] = value
+					index++
 				}
 			}
 			count++
@@ -393,7 +396,9 @@ func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
 			if valueize {
 				r.ai = append(r.ai, value.Value())
 			} else {
+				value.Index = index
 				r.a = append(r.a, value)
+				index++
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
This PR will ensure the `ContainedResult.Index` property is assigned the sequential order when `TopLevelResults.Map()` is run.

## Example Code
The JSON code used would look like this:

    {
      "stack": {
        "webserver": "nginx:1.14.0",
        "processvm": "php:7.1.18",
        "dbserver": "mysql:5.5.60",
        "webproxy": "proxy:1.14.0"
      }
    }

And then the Go code that uses the `Index` might look like this:

	type Component struct {
		Index int
		Name  string
	}
	type ComponentMap map[string]*Component
	func (p *Project) GetStack() ComponentMap {
		r:= gjson.GetBytes(p.json,"stack" )
		rm:= r.Map()
		cm := ComponentMap{}
		for t,v:= range rm {
			cm[t] = &Component{
				Index: v.Index,
				Name:  v.String(),
			}
		}
		return cm
	}

## Background 
I was using `encoding/json` and ran into the problem that the properties of JSON objects loaded would be reordered and I had no way to maintain their original order if I was modifying them and then writing them back out. I am using JSON for a configuration file that will probably be hand-modified at times, and feel it would be a very bad UX if my CLI app reordered object properties every time we updated the file.

So I found `gjson` which seems incredible -- kudos! -- but unfortunately it seems to have the same problem.  Then I noticed the `Result.Index` property and was hopeful that it would allow me to capture the original order, but unfortunately it turns out that `gjson` was actually not setting the `Result.Index` property when I needed it.

Upon further digging it appeared that it would be easy to fix `Result.arrayOrMap()` to assign `.Index` where needed, which is what I did and hence this pull request.

Note that I am a new Go programmer so I may not have handled it correctly but I certainly hope so because I would really prefer to use your official version rather than my forked version.

## Thank You!
Thanks in advance for considering this PR.


  
  
  
  
  
