### PR TITLE
Fix GetManyBytes to use byte related methods

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -1626,7 +1626,11 @@ func GetMany(json string, path ...string) []Result {
 // The return value is a Result array where the number of items
 // will be equal to the number of input paths.
 func GetManyBytes(json []byte, path ...string) []Result {
-	return GetMany(string(json), path...)
+	res := make([]Result, len(path))
+	for i, path := range path {
+		res[i] = GetBytes(json, path)
+	}
+	return res
 }
 
 var fieldsmu sync.RWMutex


### PR DESCRIPTION
## Overview

Currently `GetManyBytes ` doesn't use any of the byte related methods, but instead converts to a string. I'm unsure why https://github.com/tidwall/gjson/commit/5cd723d566400bc7ac450eb0c5b9edbb75a70750 was used other then maybe to simplify code, but I'd think it'd make more sense that if byte processing specific methods exist to use them.