### PR TITLE
Fix to handle multi json objects response

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -1002,12 +1002,10 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 							if ok {
 								res := res.Get(rp.alogkey)
 								if res.Exists() {
-									if k > 0 && len(res.String()) > 0 {
+									if k > 0 && len(res.String()) > 0 && len(jsons) > 0 {
 										jsons = append(jsons, ',')
 									}
-									if res.Type == JSON {
-										jsons = append(jsons, []byte(res.Raw)...)
-									} else if res.Type == String {
+									if res.Type == JSON || res.Type == String {
 										jsons = append(jsons, []byte(res.Raw)...)
 									} else if res.Type == Number {
 										jsons = append(jsons, []byte(res.String())...)
@@ -1021,9 +1019,6 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 						c.value.Raw = stringArray(jsons)
 						return i + 1, true
 					}
-					//if rp.alogok {
-					//	break
-					//}
 					c.value.Raw = ""
 					c.value.Type = Number
 					c.value.Num = float64(h - 1)
@@ -1084,9 +1079,6 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				} else {
 					i, val = parseSquash(c.json, i)
 					if hit {
-						//if rp.alogok {
-						//	break
-						//}
 						if len(c.value.Raw) > 1 {
 							c.value.Raw = c.value.Raw + "," + val
 						} else {

--- a/gjson.go
+++ b/gjson.go
@@ -845,7 +845,7 @@ func parseObjectPath(path string) (r objectPathResult) {
 			r.more = true
 			return
 		}
-		if path[i] == '*' || path[i] == '?' {
+		if path[i] == '*' || path[i] == '?' || r.wild == true {
 			r.wild = true
 			if (i + 1) < len(path) {
 				if path[i+1] == '.' {
@@ -993,7 +993,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				break
 			}
 			if c.json[i] == '}' {
-				if rp.wild && strings.Contains(rp.part, "*") {
+				if rp.wild && (strings.Contains(rp.part, "*") || strings.Contains(rp.part, "?")) {
 					if rp.alogok {
 						var jsons = make([]byte, 0, 64)
 

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -551,7 +551,7 @@ func TestUnicode(t *testing.T) {
 	if Get(json, "的情况下解.*?况").Num != 2 {
 		t.Fatal("fail")
 	}
-	if Get(json, "的情?下解.*?况").Num != 2 {
+	if Get(json, "的情?下解.*?况").Raw != "[2]" {
 		t.Fatal("fail")
 	}
 	if Get(json, "的情下解.*?况").Num != 0 {


### PR DESCRIPTION
Based on my understanding of this package code, I have added the capability to process multi objects response. 
Issue: https://github.com/tidwall/gjson/issues/94

This can handle the below patterns 
- `paths.*.get.description`
- `paths./mod*.post.description`
- `paths.*.*.desc`
- `paths.*.get.param.#[name=page].default`
- `paths.*.get.param.#[name%\"pag*\"].default`


