### PR TITLE
Add GetManyToMap func

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -1690,6 +1690,22 @@ func GetManyBytes(json []byte, path ...string) []Result {
 	return res
 }
 
+// GetManyToMap searches json for the multiple paths.
+// The return value is a map[string]*Result where the number of items
+// will be equal to the number of input paths.
+// And each path is the key of this map.
+func GetManyToMap(jsonStr string, args ...string) map[string]*Result {
+	results := GetMany(jsonStr, args...)
+
+	var resultMap = make(map[string]*Result)
+	for i := 0; i < len(results); i++ {
+		key := args[i]
+		value := &results[i]
+		resultMap[key] = value
+	}
+	return resultMap
+}
+
 var fieldsmu sync.RWMutex
 var fields = make(map[string]map[string]int)
 

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -1112,6 +1112,27 @@ func TestGetMany48(t *testing.T) {
 	}
 }
 
+func TestGetManyToMap(t *testing.T) {
+	json := `{"bar": {"id": 99, "xyz": "my xyz"}, "foo": {"myfoo": [605]}}`
+	paths := []string{"foo.myfoo", "bar.id", "bar.xyz", "bar.abc"}
+	expected := []string{"[605]", "99", "my xyz", ""}
+
+	results := GetManyToMap(json, paths...)
+
+	if len(expected) != len(results) {
+		t.Fatalf("expected %v, got %v", len(expected), len(results))
+	}
+	for i, path := range paths {
+		if val, ok := results[path]; ok {
+			if val.String() != expected[i] {
+				t.Fatalf("expected '%v', got '%v' for path '%v'", expected[i], val.String(), path)
+			}
+		} else {
+			t.Fatalf("expected result map has path '%v' as its key, but not exist", expected[i])
+		}
+	}
+}
+
 func TestResultRawForLiteral(t *testing.T) {
 	for _, lit := range []string{"null", "true", "false"} {
 		result := Parse(lit)


### PR DESCRIPTION
This is a simple wrapper of GetMany func. Return value is `map[string]*Result`.

 Usage example:

```
	resultMap := gjson.getManyToMap(json, "labels", "name")
	name := resultMap["name"]
        labels := resultMap["labels"]
```