### PR TITLE
Continuous fuzzing integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,25 @@
 language: go
+
+services:
+  - docker
+
+env:
+  global:
+    # FUZZIT_API_KEY
+    secure: "FEm1wF/Ttd5RIvDPg5I/aSAhBWuvkvjmkInFxlVKP4BfLsR1B1ogXV4zKFQiZugyppBta+qP4qP+tSbThSvP9JOCr+/ivnTyYLg/DH1RfQnC7rJmAaZwHGHB+NwblRzU621uIZ4RVvaE391YVJf5519gc+M+bxZ6DO0ScdpbIAVV/7JR9c7Tuvoyi57/MEwAS39k7h83ms8JgRYwuvzpVH9nb6AfYs+CzXuRlsG5mHqFnmzLyG0ewnqh18OoWbyKQwBmM+EoIGmckM8NQZaXWBhEuDP7qdl+QatNfZtK3YwBx2plahBXXMee3NpOAEHOkWxNw1uMb1B8ILDrzrx8oX1A4fF/ZeJl7JLZS/fQUMhDnLG5soA0xaEoAvwhQIHFi3e207rsq9UJsnQlRGhRWzMvx85UR5z+yiur8nVUkogu1DGpH/BPdWbTs+d8behSr7t6Sepo7enjJOPJLz6U67JlP31HvnaLICMEXxJy54BAbdu/47vqFp15lcIMHyDzPltHHWi6uGuRFQPYz8pM5ZAKQ945dO/ZELyEHbjUiLTMFeVoANzahuY56BX6hvsygcOlBWB6ukoJANvxgvM/QYkbh9dMBajYsZqHCWOKRVbBakkqPAUqkBNPOADTp5ZgUwmRySIGzX2X+Efl7cFYZVu+IJl968F8hqYajvS/VCs="
+
+jobs:
+  include:
+    - stage: Test
+      script: go test ${gobuild_args} ./...
+    
+    - stage: Fuzz regression
+      go: 1.12.x
+      dist: bionic
+      script: ./fuzzit.sh local-regression
+
+    - stage: Fuzz
+      if: branch = master AND type IN (push)
+      go: 1.12.x
+      dist: bionic
+      script: ./fuzzit.sh fuzzing

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     width="240" height="78" border="0" alt="GJSON">
 <br>
 <a href="https://travis-ci.org/tidwall/gjson"><img src="https://img.shields.io/travis/tidwall/gjson.svg?style=flat-square" alt="Build Status"></a>
+<a href="https://app.fuzzit.dev/orgs/tidwall/dashboard"><img src="https://app.fuzzit.dev/badge?org_id=tidwall"></a>
 <a href="https://godoc.org/github.com/tidwall/gjson"><img src="https://img.shields.io/badge/api-reference-blue.svg?style=flat-square" alt="GoDoc"></a>
 <a href="http://tidwall.com/gjson-play"><img src="https://img.shields.io/badge/%F0%9F%8F%90-playground-9900cc.svg?style=flat-square" alt="GJSON Playground"></a>
 </p>

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -xe
+
+# Validate arguments
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <fuzz-type>"
+    exit 1
+fi
+if [ -z "$FUZZIT_API_KEY" ]; then
+    echo "Set FUZZIT_API_KEY to your Fuzzit API key"
+    exit 2
+fi
+
+# Configure
+NAME=gjson
+TYPE=$1
+
+# Setup
+export GO111MODULE="off"
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+go get -d -v -u ./...
+if [ ! -f fuzzit ]; then
+    wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+    chmod a+x fuzzit
+fi
+
+# Fuzz
+function fuzz {
+    FUNC=Fuzz$1
+    TARGET=$NAME${2:+-$2}
+    DIR=${3:-.}
+    go-fuzz-build -libfuzzer -func $FUNC -o fuzzer.a $DIR
+    clang -fsanitize=fuzzer fuzzer.a -o fuzzer
+    ./fuzzit create job --type $TYPE $TARGET fuzzer
+}
+fuzz Parse parse
+fuzz Path path

--- a/gjson_fuzz.go
+++ b/gjson_fuzz.go
@@ -1,0 +1,35 @@
+// +build gofuzz
+
+package gjson
+
+// FuzzParse tests JSON parsing
+func FuzzParse(fuzz []byte) int {
+	valid := ValidBytes(fuzz)
+	if !valid {
+		return 0
+	}
+	ParseBytes(fuzz)
+	return 1
+}
+
+// FuzzPath tests search for GJSON path
+func FuzzPath(fuzz []byte) int {
+	if len(fuzz) < 3 {
+		return -1
+	}
+	length := uint8(fuzz[0])
+	if length == 0 {
+		return -1
+	}
+	if len(fuzz) < int(length+2) {
+		return -1
+	}
+	path := string(fuzz[1 : length+1])
+	json := fuzz[length+1:]
+	valid := ValidBytes(json)
+	if !valid {
+		return 0
+	}
+	GetBytes(json, path)
+	return 1
+}

--- a/gjson_fuzz.go
+++ b/gjson_fuzz.go
@@ -21,7 +21,7 @@ func FuzzPath(fuzz []byte) int {
 	if length == 0 {
 		return -1
 	}
-	if len(fuzz) < int(length+2) {
+	if len(fuzz) < int(length)+2 {
 		return -1
 	}
 	path := string(fuzz[1 : length+1])


### PR DESCRIPTION
Hi @tidwall, thanks for the package. I've used it in another project. The API is nice and clean.

I was wondering if you'd like to get fuzzing running. [Fuzzit](https://fuzzit.dev/) gives free service for open source.

I've gone for a couple targets in this patch, JSON parsing and searching with a GJSON path. Fuzzing the search found a few interesting crashes. I'll post in a comment.

There's a [successful build](https://travis-ci.org/bookmoons/gjson/builds/576117901) under my Travis account. The PR build will fail because it's missing the API key. If you want to try it setup is like this:
* In Fuzzit create targets `gjson-parse` `gjson-path`.
* In Fuzzit settings grab an API key. In repo settings in [Travis](https://travis-ci.org/) paste it to envvar `FUZZIT_API_KEY`.

Thanks for looking at it.