### PR TITLE
Add @this modifier

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -186,6 +186,7 @@ There are currently three built-in modifiers:
 - `@reverse`: Reverse an array or the members of an object.
 - `@ugly`: Remove all whitespace from JSON.
 - `@pretty`: Make the JSON more human readable.
+- `@this`: Returns the current element. Can be used to retrieve the root element.
 
 #### Modifier arguments
 

--- a/gjson.go
+++ b/gjson.go
@@ -1989,7 +1989,7 @@ func runeit(json string) rune {
 }
 
 // unescape unescapes a string
-func unescape(json string) string { //, error) {
+func unescape(json string) string { // , error) {
 	var str = make([]byte, 0, len(json))
 	for i := 0; i < len(json); i++ {
 		switch {
@@ -2746,6 +2746,7 @@ var modifiers = map[string]func(json, arg string) string{
 	"pretty":  modPretty,
 	"ugly":    modUgly,
 	"reverse": modReverse,
+	"this":    modThis,
 }
 
 // AddModifier binds a custom modifier command to the GJSON syntax.
@@ -2781,6 +2782,11 @@ func modPretty(json, arg string) string {
 		return bytesString(pretty.PrettyOptions(stringBytes(json), &opts))
 	}
 	return bytesString(pretty.Pretty(stringBytes(json)))
+}
+
+// @this returns the current element. Can be used to retrieve the root element.
+func modThis(json, arg string) string {
+	return json
 }
 
 // @ugly modifier removes all whitespace.

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -1519,6 +1519,12 @@ func TestModifier(t *testing.T) {
 	if res != json {
 		t.Fatalf("expected '%v', got '%v'", json, res)
 	}
+	if res := Get(res, "@this").String(); res != json {
+		t.Fatalf("expected '%v', got '%v'", json, res)
+	}
+	if res := Get(res, "other.@this").String(); res != `{"hello":"world"}` {
+		t.Fatalf("expected '%v', got '%v'", json, res)
+	}
 	res = Get(res, "@pretty|@reverse|arr|@reverse|2").String()
 	if res != "4" {
 		t.Fatalf("expected '%v', got '%v'", "4", res)


### PR DESCRIPTION
This modifier returns the current element as-is and can be used
to retrieve the JSON document itself. It is equivalent to the `#/` JSON Pointer.

Closes #149