### PR TITLE
Add support to return multiple indexes when multiple matches are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ nil, for JSON null
 To directly access the value:
 
 ```go
-result.Type    // can be String, Number, True, False, Null, or JSON
-result.Str     // holds the string
-result.Num     // holds the float64 number
-result.Raw     // holds the raw json
-result.Index   // index of raw value in original json, zero means index unknown
+result.Type           // can be String, Number, True, False, Null, or JSON
+result.Str            // holds the string
+result.Num            // holds the float64 number
+result.Raw            // holds the raw json
+result.Index          // index of raw value in original json, zero means index unknown
+result.HashtagIndexes // hashtagIndexes contains the indexes of the elements returned by a query containing the '#' character
 ```
 
 There are a variety of handy functions that work on a result:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ result.Str            // holds the string
 result.Num            // holds the float64 number
 result.Raw            // holds the raw json
 result.Index          // index of raw value in original json, zero means index unknown
-result.HashtagIndexes // hashtagIndexes contains the indexes of the elements returned by a query containing the '#' character
+result.Indexes        // Indexes contains the indexes of the elements returned by a query containing the '#' character
 ```
 
 There are a variety of handy functions that work on a result:

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -859,9 +859,9 @@ func TestIssue20(t *testing.T) {
 }
 
 func TestIssue21(t *testing.T) {
-	json := `{ "Level1Field1":3, 
-	           "Level1Field4":4, 
-			   "Level1Field2":{ "Level2Field1":[ "value1", "value2" ], 
+	json := `{ "Level1Field1":3,
+	           "Level1Field4":4,
+			   "Level1Field2":{ "Level2Field1":[ "value1", "value2" ],
 			   "Level2Field2":{ "Level3Field1":[ { "key1":"value1" } ] } } }`
 	paths := []string{"Level1Field1", "Level1Field2.Level2Field1",
 		"Level1Field2.Level2Field2.Level3Field1", "Level1Field4"}
@@ -922,7 +922,7 @@ var complicatedJSON = `
 	"nestedTagged": {
 		"Green": "Green",
 		"Map": {
-			"this": "that", 
+			"this": "that",
 			"and": "the other thing"
 		},
 		"Ints": {
@@ -1291,10 +1291,10 @@ func TestArrayValues(t *testing.T) {
 	}
 	expect := strings.Join([]string{
 		`gjson.Result{Type:3, Raw:"\"PERSON1\"", Str:"PERSON1", Num:0, ` +
-			`Index:0, HashtagIndexes:[]int(nil)}`,
+			`Index:0, Indexes:[]int(nil)}`,
 		`gjson.Result{Type:3, Raw:"\"PERSON2\"", Str:"PERSON2", Num:0, ` +
-			`Index:0, HashtagIndexes:[]int(nil)}`,
-		`gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:0, HashtagIndexes:[]int(nil)}`,
+			`Index:0, Indexes:[]int(nil)}`,
+		`gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:0, Indexes:[]int(nil)}`,
 	}, "\n")
 	if output != expect {
 		t.Fatalf("expected '%v', got '%v'", expect, output)
@@ -1492,7 +1492,7 @@ func TestDeepSelectors(t *testing.T) {
 					}
 				},
 				{
-					"first": "Roger", "last": "Craig", 
+					"first": "Roger", "last": "Craig",
 					"extra": [40,50,60],
 					"details": {
 						"city": "Phoenix",
@@ -2122,7 +2122,7 @@ func TestModifierDoubleQuotes(t *testing.T) {
 
 }
 
-func TestHashtagIndexes(t *testing.T) {
+func TestIndexes(t *testing.T) {
 	var exampleJSON = `{
 		"vals": [
 			[1,66,{test: 3}],
@@ -2150,14 +2150,18 @@ func TestHashtagIndexes(t *testing.T) {
 			`objectArray.#(age>43)#.first`,
 			[]string{`"`, `"`},
 		},
+		{
+			`objectArray.@reverse.#.first`,
+			nil,
+		},
 	}
 
 	for _, tc := range testCases {
 		r := Get(exampleJSON, tc.path)
 
-		assert(t, len(r.HashtagIndexes) == len(tc.expected))
+		assert(t, len(r.Indexes) == len(tc.expected))
 
-		for i, a := range r.HashtagIndexes {
+		for i, a := range r.Indexes {
 			assert(t, string(exampleJSON[a]) == tc.expected[i])
 		}
 	}
@@ -2178,10 +2182,10 @@ func TestHashtagIndexesMatchesRaw(t *testing.T) {
 				if v.IsArray() {
 					v.ForEach(func(_, sv Result) bool {
 						if sv.IsObject() {
-							assert(t, string(exampleJSON[r.HashtagIndexes[0]:r.HashtagIndexes[0]+len(sv.Raw)]) == sv.Raw)
+							assert(t, string(exampleJSON[r.Indexes[0]:r.Indexes[0]+len(sv.Raw)]) == sv.Raw)
 						}
 						if sv.IsArray() {
-							assert(t, string(exampleJSON[r.HashtagIndexes[1]:r.HashtagIndexes[1]+len(sv.Raw)]) == sv.Raw)
+							assert(t, string(exampleJSON[r.Indexes[1]:r.Indexes[1]+len(sv.Raw)]) == sv.Raw)
 						}
 						return true
 					})

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -1291,10 +1291,10 @@ func TestArrayValues(t *testing.T) {
 	}
 	expect := strings.Join([]string{
 		`gjson.Result{Type:3, Raw:"\"PERSON1\"", Str:"PERSON1", Num:0, ` +
-			`Index:0}`,
+			`Index:0, HashtagIndexes:[]int(nil)}`,
 		`gjson.Result{Type:3, Raw:"\"PERSON2\"", Str:"PERSON2", Num:0, ` +
-			`Index:0}`,
-		`gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:0}`,
+			`Index:0, HashtagIndexes:[]int(nil)}`,
+		`gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:0, HashtagIndexes:[]int(nil)}`,
 	}, "\n")
 	if output != expect {
 		t.Fatalf("expected '%v', got '%v'", expect, output)

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -859,9 +859,9 @@ func TestIssue20(t *testing.T) {
 }
 
 func TestIssue21(t *testing.T) {
-	json := `{ "Level1Field1":3, 
-	           "Level1Field4":4, 
-			   "Level1Field2":{ "Level2Field1":[ "value1", "value2" ], 
+	json := `{ "Level1Field1":3,
+	           "Level1Field4":4,
+			   "Level1Field2":{ "Level2Field1":[ "value1", "value2" ],
 			   "Level2Field2":{ "Level3Field1":[ { "key1":"value1" } ] } } }`
 	paths := []string{"Level1Field1", "Level1Field2.Level2Field1",
 		"Level1Field2.Level2Field2.Level3Field1", "Level1Field4"}
@@ -922,7 +922,7 @@ var complicatedJSON = `
 	"nestedTagged": {
 		"Green": "Green",
 		"Map": {
-			"this": "that", 
+			"this": "that",
 			"and": "the other thing"
 		},
 		"Ints": {
@@ -1492,7 +1492,7 @@ func TestDeepSelectors(t *testing.T) {
 					}
 				},
 				{
-					"first": "Roger", "last": "Craig", 
+					"first": "Roger", "last": "Craig",
 					"extra": [40,50,60],
 					"details": {
 						"city": "Phoenix",
@@ -2119,4 +2119,51 @@ func TestModifierDoubleQuotes(t *testing.T) {
 		`{"name":"Product P4","value":"{\"productId\":\"1cc3\",\"vendorId\":\"20de\"}"},`+
 		`{"name":"Product P4","value":"{\"productId\":\"1dd3\",\"vendorId\":\"30de\"}"}`+
 		`]`)
+
+}
+
+func TestArrayIndex(t *testing.T) {
+	json := `{
+		"vals": [
+			[
+				2,
+				2,
+				{
+					"wut",
+					"yup"
+				}
+			],
+			[
+				4,
+				5,
+				6
+			]
+		]
+	}`
+	r := Get(json, `vals.#.2`)
+	fmt.Println(r.ArrayIndex)
+	fmt.Println(string(json[37]))
+
+	all := Get(json, `@this`)
+	all.ForEach(func(_, value Result) bool {
+		println(value.Raw, "index", value.Index)
+		println(string(json[value.Index : value.Index+len(value.Raw)]))
+		if value.IsArray() {
+			value.ForEach(func(_, v Result) bool {
+				println(v.Raw, "index", v.Index)
+				parentIndex := value.Index + v.Index
+				println(string(json[parentIndex : parentIndex+len(v.Raw)]))
+
+				if v.IsArray() {
+					v.ForEach(func(_, sv Result) bool {
+						println(sv.Raw, "index", sv.Index+parentIndex)
+						println(string(json[sv.Index+parentIndex : sv.Index+parentIndex+len(sv.Raw)]))
+						return true
+					})
+				}
+				return true
+			})
+		}
+		return true // keep iterating
+	})
 }

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -922,7 +922,7 @@ var complicatedJSON = `
 	"nestedTagged": {
 		"Green": "Green",
 		"Map": {
-			"this": "that",
+			"this": "that", 
 			"and": "the other thing"
 		},
 		"Ints": {


### PR DESCRIPTION
This pull request adds a new field to the `Result` structure that will contain multiple indexes when multiple matches are found. Currently only a single index is provided that is set to 0 when you provide a query to gather multiple matches (a query to access multiple child paths `"friends.#.first"` or to find all matches `#(...)#`). I called the new field `HashtagIndexes` because I believe this should only apply when a query uses a hashtag (but definitely open to any other name suggestions).

I am working on a project that would benefit from knowing all the indexes, I added a unit test called `TestHashtagIndexesMatchesRaw` that is very similar to what I would like to do with this feature. Basically run two separate queries and walk over the results of one and use the indexes to find matches. Thank you for looking over this pull request! Hopefully this is the right approach to achieve this.