### PR TITLE
Quick typo

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -291,8 +291,8 @@ gjson.AddModifier("case", func(json, arg string) string {
 ### Multipaths
 
 Starting with v1.3.0, GJSON added the ability to join multiple paths together
-to form new documents. Wrapping comma-separated paths between `{...}` or 
-`[...]` will result in a new array or object, respectively.
+to form new documents. Wrapping comma-separated paths between `[...]` or
+`{...}` will result in a new array or object, respectively.
 
 For example, using the given multipath 
 


### PR DESCRIPTION
The respective position of array and object were switched in `SYNTAX.md` when [talking about Multipaths](https://github.com/tidwall/gjson/blob/2feb4037b471139e7449b6e4e97e232ff1c39d4a/SYNTAX.md#multipaths). 