### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Getting Started
 To start using GJSON, install Go and run `go get`:
 
 ```sh
-$ go get -u github.com/tidwall/gjson
+$ go get -u github.com/tidwall/gjson < v1.17
+
+$ go install github.com/tidwall/gjson >= v1.17
 ```
 
 This will retrieve the library.
@@ -445,15 +447,15 @@ Benchmarks of GJSON alongside [encoding/json](https://golang.org/pkg/encoding/js
 and [json-iterator](https://github.com/json-iterator/go)
 
 ```
-BenchmarkGJSONGet-16                11644512       311 ns/op       0 B/op	       0 allocs/op
-BenchmarkGJSONUnmarshalMap-16        1122678      3094 ns/op    1920 B/op	      26 allocs/op
-BenchmarkJSONUnmarshalMap-16          516681      6810 ns/op    2944 B/op	      69 allocs/op
-BenchmarkJSONUnmarshalStruct-16       697053      5400 ns/op     928 B/op	      13 allocs/op
-BenchmarkJSONDecoder-16               330450     10217 ns/op    3845 B/op	     160 allocs/op
-BenchmarkFFJSONLexer-16              1424979      2585 ns/op     880 B/op	       8 allocs/op
-BenchmarkEasyJSONLexer-16            3000000       729 ns/op     501 B/op	       5 allocs/op
-BenchmarkJSONParserGet-16            3000000       366 ns/op      21 B/op	       0 allocs/op
-BenchmarkJSONIterator-16             3000000       869 ns/op     693 B/op	      14 allocs/op
+BenchmarkGJSONGet-16                11644512       311 ns/op       0 B/op	      0 allocs/op
+BenchmarkGJSONUnmarshalMap-16        1122678      3094 ns/op    1920 B/op	     26 allocs/op
+BenchmarkJSONUnmarshalMap-16          516681      6810 ns/op    2944 B/op	     69 allocs/op
+BenchmarkJSONUnmarshalStruct-16       697053      5400 ns/op     928 B/op	     13 allocs/op
+BenchmarkJSONDecoder-16               330450     10217 ns/op    3845 B/op	    160 allocs/op
+BenchmarkFFJSONLexer-16              1424979      2585 ns/op     880 B/op	      8 allocs/op
+BenchmarkEasyJSONLexer-16            3000000       729 ns/op     501 B/op	      5 allocs/op
+BenchmarkJSONParserGet-16            3000000       366 ns/op      21 B/op	      0 allocs/op
+BenchmarkJSONIterator-16             3000000       869 ns/op     693 B/op	     14 allocs/op
 ```
 
 JSON document used:


### PR DESCRIPTION
Golang does not support `go get -u` anymore for v1.17+