### PR TITLE
fix object path parse error

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -1009,8 +1009,8 @@ func parseObjectPath(path string) (r objectPathResult) {
 							r.piped = true
 						} else {
 							r.path = path[i+1:]
+							r.more = true
 						}
-						r.more = true
 						return
 					} else if path[i] == '|' {
 						r.part = string(epart)


### PR DESCRIPTION
source json:
```json
{
  "name": {"first": "Tom", "last": "Anderson"},
  "age":37,
  "children": ["Sara","Alex","Jack"],
  "fav.movie": ["Deer Hunter"],
  "friends": [
    {"first": "Dale", "last": "Murphy", "age": 44, "nets": ["ig", "fb", "tw"]},
    {"first": "Roger", "last": "Craig", "age": 68, "nets": ["fb", "tw"]},
    {"first": "Jane", "last": "Murphy", "age": 47, "nets": ["ig", "tw"]}
  ]
}
```
query: `fav\.movie.[0]`
expected: `["Deer Hunter"]`