### PR TITLE
Encode \b and \f in JSON string as themselves

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -1926,6 +1926,10 @@ func AppendJSONString(dst []byte, s string) []byte {
 		if s[i] < ' ' {
 			dst = append(dst, '\\')
 			switch s[i] {
+			case '\b':
+				dst = append(dst, 'b')
+			case '\f':
+				dst = append(dst, 'f')
 			case '\n':
 				dst = append(dst, 'n')
 			case '\r':

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -2578,6 +2578,7 @@ func TestJSONString(t *testing.T) {
 	testJSONString(t, s)
 	testJSONString(t, "R\xfd\xfc\a!\x82eO\x16?_\x0f\x9ab\x1dr")
 	testJSONString(t, "_\xb9\v\xad\xb3|X!\xb6\xd9U&\xa4\x1a\x95\x04")
+	testJSONString(t, "\b\f")
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	start := time.Now()
 	var buf [16]byte


### PR DESCRIPTION
This PR fixes a test failure by adapting `AppendJSONString` to follow the new behavior of [encoding/json](https://tip.golang.org/pkg/encoding/json) in Go 1.22. The corresponding test case is appended by a check of the `\b` and `\f` characters.

Since Go 1.22 the encoding/json library encodes the characters `\b` and `\f` as themselves. Before 1.22 they were encoded as `\u0008` and `\u000c`. The new behavior fails `TestJSONString`:

```
--- FAIL: TestJSONString (0.00s)
    gjson_test.go:2560: "1&$'\f\x16\xfa\xbah\xc9zz\x89DR\xf3"
                "1\u0026$'\u000c\u0016\ufffd\ufffdh\ufffdzz\ufffdDR\ufffd"
                "1\u0026$'\f\u0016\ufffd\ufffdh\ufffdzz\ufffdDR\ufffd"
                <<< MISMATCH >>>
```

Go 1.22 release notes: https://tip.golang.org/doc/go1.22#minor_library_changes