### PR TITLE
Allow for pooling by allowing reuse of a Result object

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -527,14 +527,14 @@ func (value *Result) Parse(json string) {
 			value.Type = String
 			value.Raw, value.Str = tostr(json[i:])
 		default:
-			return Result{}
+			value.Clear()
+			return
 		}
 		break
 	}
 	if value.Exists() {
 		value.Index = i
 	}
-	return value
 }
 
 // ParseBytes parses the json and returns a result.

--- a/gjson.go
+++ b/gjson.go
@@ -469,6 +469,29 @@ end:
 // use the Valid function first.
 func Parse(json string) Result {
 	var value Result
+	value.Parse(json)
+	return value
+}
+
+// Clear for pooling
+func (value *Result) Clear() {
+	value.Type = 0
+	value.Raw = ""
+	value.Str = ""
+	value.Num = 0
+	value.Index = 0
+	if value.Indexes != nil {
+		value.Indexes = value.Indexes[:0]
+	}
+}
+
+// ParseBytes into an existing Result
+func (value *Result) ParseBytes(json []byte) {
+	value.Parse(string(json))
+}
+
+// Parse into an existing Result
+func (value *Result) Parse(json string) {
 	i := 0
 	for ; i < len(json); i++ {
 		if json[i] == '{' || json[i] == '[' {

--- a/gjson.go
+++ b/gjson.go
@@ -293,7 +293,7 @@ func (t Result) ForEach(iterator func(key, value Result) bool) {
 		if !ok {
 			return
 		}
-		if t.Indexes != nil {
+		if len(t.Indexes) > 0 {
 			if idx < len(t.Indexes) {
 				value.Index = t.Indexes[idx]
 			}
@@ -321,7 +321,7 @@ func (t Result) Map() map[string]Result {
 // The result should be a JSON array or object.
 func (t Result) Get(path string) Result {
 	r := Get(t.Raw, path)
-	if r.Indexes != nil {
+	if len(r.Indexes) > 0 {
 		for i := 0; i < len(r.Indexes); i++ {
 			r.Indexes[i] += t.Index
 		}
@@ -447,7 +447,7 @@ func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
 		}
 	}
 end:
-	if t.Indexes != nil {
+	if len(t.Indexes) > 0 {
 		if len(t.Indexes) != len(r.a) {
 			for i := 0; i < len(r.a); i++ {
 				r.a[i].Index = 0
@@ -3454,7 +3454,7 @@ func revSquash(json string) string {
 // when the Result came from a path that contained a multipath, modifier,
 // or a nested query.
 func (t Result) Paths(json string) []string {
-	if t.Indexes == nil {
+	if len(t.Indexes) == 0 {
 		return nil
 	}
 	paths := make([]string, 0, len(t.Indexes))


### PR DESCRIPTION
In profiling we've found that the garbage associated with Parse and ParseBytes is dominating our application and I would like to introduce a sync.Pool of the parsed results.  This MR exposes the Parse function as a decorator of the Result and adds a Clear() function in order to guarantee safe reuse.  