### PR TITLE
add modifier key2obj

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -2932,6 +2932,7 @@ func init() {
 		"fromstr": modFromStr,
 		"group":   modGroup,
 		"dig":     modDig,
+		"key2obj": modKey2Obj,
 	}
 }
 
@@ -3140,6 +3141,54 @@ func modValues(json, arg string) string {
 			out.WriteByte(',')
 		}
 		out.WriteString(value.Raw)
+		i++
+		return true
+	})
+	out.WriteByte(']')
+	return out.String()
+}
+
+// @values appends key name as value in child object under "_key"
+//
+//	{"Tom Smith": { "height": 170 ,"weight": 80} } -> {"_key": "Tom Smith", "height": 170 ,"weight": 80} }
+func modKey2Obj(json, arg string) string {
+	v := Parse(json)
+	if !v.Exists() {
+		return "[]"
+	}
+	if v.IsArray() {
+		return json
+	}
+	var out strings.Builder
+	out.WriteByte('{')
+
+	var i int
+	v.ForEach(func(rootKey, rootValue Result) bool {
+		if i > 0 {
+			out.WriteByte(',')
+		}
+		out.WriteString(rootKey.Raw)
+		out.WriteString(":")
+
+		if rootValue.IsObject() {
+
+			out.WriteByte('{')
+
+			rootValue.ForEach(func(childKey, childValue Result) bool {
+				out.WriteString(childKey.Raw)
+				out.WriteString(":")
+				out.WriteString(childValue.Raw)
+				out.WriteByte(',')
+				return true
+			})
+			out.WriteString("\"_key\":")
+			out.WriteString(rootKey.Raw)
+
+			out.WriteByte('}')
+
+		} else {
+			out.WriteString(rootValue.Raw)
+		}
 		i++
 		return true
 	})

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -2727,3 +2727,29 @@ func TestEscape(t *testing.T) {
 	assert(t, user.Get(Escape("last.name")).String() == "Prichard")
 	assert(t, user.Get("first.name").String() == "")
 }
+
+func TestModKey2Obj(t *testing.T) {
+	json := `
+		{
+			"tickets": {
+				"ISSUE-10": {
+						"subject": "foo",
+						"priority": 1,
+						"id": 123
+				},
+				"ISSUE-12": {
+						"subject": "bar",
+						"priority": 3,
+						"id": 124
+				},
+				"ISSUE-17": {
+						"subject": "baz",
+						"priority": 2,
+						"id": 1128
+				}
+			}
+		}
+	`
+	assert(t, Get(json, "tickets.@key2obj.@values.#._key").String() == `["ISSUE-10","ISSUE-12","ISSUE-17"]`)
+	assert(t, Get(json, "tickets.@key2obj.@values.0").String() == `{"subject":"foo","priority":1,"id":123,"_key":"ISSUE-10"}`)
+}


### PR DESCRIPTION
Pull request adds key2obj modifier function. It was made to allow handling of the APIs responses like below, which instead of providing a list, nest objects under parent object keys effectively representing child object name/identifier. key2obj appends key from parent to children under "_key". This creates flat structure which can be processed further without loosing information from parent key.

It could be usefull for apps which heavily depend on user configurable JSON queries, handling generic data, from wild APIs (occured to me on telegraf with json_v2 parsers and ).

```
		{
			"tickets": {
				"ISSUE-10": {
						"subject": "foo",
						"priority": 1,
						"id": 123
				},
				"ISSUE-12": {
						"subject": "bar",
						"priority": 3,
						"id": 124
				},
				"ISSUE-17": {
						"subject": "baz",
						"priority": 2,
						"id": 1128
				}
			}
		}
```


```
tickets.@key2obj

		{
			"tickets": {
				"ISSUE-10": {
						"subject": "foo",
						"priority": 1,
						"id": 123,
						"_key": "ISSUE-10"
				},
				"ISSUE-12": {
						"subject": "bar",
						"priority": 3,
						"id": 124,
						"_key": "ISSUE-10"
				},
				"ISSUE-17": {
						"subject": "baz",
						"priority": 2,
						"id": 1128,
						"_key": "ISSUE-10"
				}
			}
		}
```

```
tickets.@key2obj.@values
```
				[{
						"subject": "foo",
						"priority": 1,
						"id": 123,
						"_key": "ISSUE-10"
				},
				{
						"subject": "bar",
						"priority": 3,
						"id": 124,
						"_key": "ISSUE-10"
				},
				{
						"subject": "baz",
						"priority": 2,
						"id": 1128,
						"_key": "ISSUE-10"
				}]
		
```