### PR TITLE
Add IsString and IsNumber helper method

### DIFF
--- a/gjson.go
+++ b/gjson.go
@@ -224,6 +224,16 @@ func (t Result) IsBool() bool {
 	return t.Type == True || t.Type == False
 }
 
+// IsNumber returns true if the result value is a JSON number.
+func (t Result) IsNumber() bool {
+	return t.Type == Number
+}
+
+// IsString returns true if the result value is a JSON string.
+func (t Result) IsString() bool {
+	return t.Type == String
+}
+
 // ForEach iterates through values.
 // If the result represents a non-existent value, then no values will be
 // iterated. If the result is an Object, the iterator will pass the key and


### PR DESCRIPTION
This PR adds two new helper methods to the Result type:

- `IsNumber()`: Returns true if the result value is a JSON number
- `IsString()`: Returns true if the result value is a JSON string

These methods complete the set of type-checking functions for JSON values. Prior to this PR, the package already included `IsObject()`, `IsArray()`, and `IsBool()` methods, but was missing equivalent methods for checking **number** and **string** types.

Refer to the discussion in #44 , so the `IsNull()` method was not added.

